### PR TITLE
SortableTable item numbers shoud be permalinks

### DIFF
--- a/src/components/sortable_table/row.js
+++ b/src/components/sortable_table/row.js
@@ -142,9 +142,17 @@ var TableRow = React.createClass({
   },
 
   buildNumberCell: function(styles) {
+    var props = {
+      href: this.props.baseUrl + '/product/' + this.props.model.product.id + '/item/' + this.props.model.number,
+      className: 'js-item-link title-cell',
+      'data-item-number': this.props.model.number,
+      style: this.state.hover ? Styles.cell.linkHover : Styles.cell.link,
+      onMouseOver: this.onTitleLinkHover,
+      onMouseOut: this.onTitleLinkOut
+    };
     return (
       <div style={styles}>
-        #{this.props.model.number}
+        <a {...props}>#{this.props.model.number}</a>
       </div>
     );
   },

--- a/src/styles/sortable_table.js
+++ b/src/styles/sortable_table.js
@@ -128,7 +128,8 @@ var SortableTableStyles = {
       width: '375px'
     },
     link: {
-      color: '#323232'
+      color: '#323232',
+      textDecoration: 'none'
     },
     linkHover: {
       color: '#323232',

--- a/test/sortable_table_test.js
+++ b/test/sortable_table_test.js
@@ -31,11 +31,16 @@ var genItem = function(num, productNum, userName, parentNum) {
 describe('SortableTable', function() {
   describe('rendering', function() {
     beforeEach(function() {
+      this.items = [
+        genItem(1,1,'amy',5),
+        genItem(2,2,'bob',5),
+        genItem(5,2,'amy')
+      ];
       this.sortable = TestUtils.renderIntoDocument(
         <SortableTable
           tableType="backlog"
           label="backlog"
-          collection={[genItem(1,1,'amy',5), genItem(2,2,'bob',5), genItem(5,2,'amy')]}
+          collection={this.items}
           columnNames={['product','number','size','title','assigned to','created by','tags','created']}
           onSortCollection={_.noop()}
         />
@@ -60,6 +65,17 @@ describe('SortableTable', function() {
       _.each([this.sortable.props.columnNames, headerCols, rowCols], function(cols) {
         assert.equal(cols.length, 8);
       });
+    });
+
+    it('should render the item number be a permalink', function() {
+      var row = TestUtils.scryRenderedComponentsWithType(this.sortable, Row)[0];
+      var rowCols = TestUtils.scryRenderedDOMComponentsWithTag(row, 'td');
+      var anchors = TestUtils.scryRenderedDOMComponentsWithTag(rowCols[1], 'a')
+      var item = this.items[0];
+      var node = anchors[0].getDOMNode();
+
+      assert.equal(node.text, '#' + item.number);
+      assert.include(node.href, item.product.id + '/item/' + item.number);
     });
 
     it('should render a table row for each collection item', function() {


### PR DESCRIPTION
#### What does it do?
Makes the item number in SortableTable a permalink.

#### How should it be manually tested?
Link to your local project or build & fire up `open examples/tables.html`

### Where should the reviewer start?
src/components/sortable_table/row.js

#### Background context?
Using the same cues as the `title` permalink, so this is a pretty simple change. Yay for easy testing of this type of stuff!

#### What are the relevant tickets?
Fixes #9239

#### Screenshots
![screen shot 2015-02-25 at 9 58 57 pm](https://cloud.githubusercontent.com/assets/84644/6387073/8fea0602-bd39-11e4-932d-681f3871fba2.png)

#### What GIF best describes this pull request?
![1cf23874](https://cloud.githubusercontent.com/assets/84644/6387213/1bb7b74a-bd3c-11e4-911a-42a3e3b39da9.gif)

#### Definition of done:
- [x] Is this appropriately tested?
- [x] Does this need an update to the README or documentation?
- [x] Does this need an update to the examples?
- [x] Does this add new dependencies?
- [x] Does this require a semver version bump?
  - [ ] MAJOR
  - [ ] MINOR
  - [x] PATH