### PR TITLE
fixes #9237 — xpm product name should be a link

### DIFF
--- a/src/components/sortable_table/row.js
+++ b/src/components/sortable_table/row.js
@@ -122,6 +122,11 @@ var TableRow = React.createClass({
   },
 
   buildProductCell: function(styles) {
+    var linkProps = {
+      href: this.props.baseUrl + '/product/' + this.props.model.product.id,
+      className: 'js-item-link title-cell',
+      style: Styles.cell.link
+    };
     var subitemArrow = null;
     var subitemArrowStyles = this.props.expanded === 'expanded' ?
       _.extend({}, Styles.cell.subitemArrow, Styles.cell.subitemArrowExpanded) :
@@ -136,7 +141,7 @@ var TableRow = React.createClass({
     return (
       <div style={_.extend({}, styles, Styles.cell.wider)}>
         {subitemArrow}
-        {this.props.model.product.name}
+        <a {...linkProps}>{this.props.model.product.name}</a>
       </div>
     );
   },

--- a/test/sortable_table_test.js
+++ b/test/sortable_table_test.js
@@ -16,7 +16,7 @@ var TagEditor = require('../src/components/tag_editor');
 var genItem = function(num, productNum, userName, parentNum) {
   return {
     number: num,
-    product: {id: productNum},
+    product: {id: productNum, name: 'foo'},
     type: 'defect',
     title: "Test item",
     status: 'backlog',
@@ -65,6 +65,17 @@ describe('SortableTable', function() {
       _.each([this.sortable.props.columnNames, headerCols, rowCols], function(cols) {
         assert.equal(cols.length, 8);
       });
+    });
+
+    it('should render the product name as a permalink', function() {
+      var row = TestUtils.scryRenderedComponentsWithType(this.sortable, Row)[0];
+      var rowCols = TestUtils.scryRenderedDOMComponentsWithTag(row, 'td');
+      var anchors = TestUtils.scryRenderedDOMComponentsWithTag(rowCols[0], 'a')
+      var item = this.items[0];
+      var node = anchors[0].getDOMNode();
+
+      assert.equal(node.text, item.product.name);
+      assert.include(node.href, item.product.id);
     });
 
     it('should render the item number be a permalink', function() {


### PR DESCRIPTION
#### What does it do?
Makes the product name in SortableTable a permalink.

#### How should it be manually tested?
Link to your local project or build & fire up `open examples/tables.html`

### Where should the reviewer start?
src/components/sortable_table/row.js

#### What are the relevant tickets?
Fixes #9237

#### Definition of done:
- [x] Is this appropriately tested?
- [x] Does this need an update to the README or documentation?
- [x] Does this need an update to the examples?
- [x] Does this add new dependencies?
- [x] Does this require a semver version bump?
  - [ ] MAJOR
  - [ ] MINOR
  - [x] PATH