### PR TITLE
Fix Selector Props

### DIFF
--- a/src/components/selector_menu/index.js
+++ b/src/components/selector_menu/index.js
@@ -31,15 +31,13 @@ var SelectorMenu = React.createClass({
 
   getDefaultProps: function() {
     return {
-      defaultSelection: 'All',
       optionsList: []
     };
   },
 
   getInitialState: function() {
     return {
-      selected: this.props.defaultSelection,
-      visible: this.getOptionNames(),
+      visible: [],
       expanded: false
     };
   },
@@ -75,7 +73,7 @@ var SelectorMenu = React.createClass({
     this.refs.searchInput.getDOMNode().value = '';
 
     this.setState({
-      visible: this.getOptionNames()
+      visible: []
     });
   },
 
@@ -128,23 +126,30 @@ var SelectorMenu = React.createClass({
       return;
     }
 
-    var visible = _.map(fuzzy.filter(filterBy, this.state.visible), function(result) {
-      return result.string;
-    });
+    var visible = _.pluck(fuzzy.filter(filterBy, this.getOptionNames()), 'string');
 
     this.setState({
       visible: visible
     });
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    if (nextProps.optionsList.length !== this.props.optionsList.length) {
+      this.setState({ visible: [] });
+    }
+  },
+
   render: function() {
     var wrapperClass = this.state.expanded ? 'selector__wrapper expanded' : 'selector__wrapper';
     var innerClass = this.state.expanded ? 'inner-wrapper expanded' : 'inner-wrapper';
+    var visible = this.state.visible.length > 0 ? this.state.visible : this.getOptionNames();
+    var selected = this.state.selected && this.props.defaultSelection === undefined ?
+      this.state.selected : this.props.defaultSelection || 'All';
 
     return (
       <div className={wrapperClass}>
         <Label
-          selected={this.state.selected}
+          selected={selected}
           onClick={this.onLabelClicked}
         />
         <div className={innerClass}>
@@ -154,8 +159,8 @@ var SelectorMenu = React.createClass({
             filterList={this.filterList}
           />
           <List
-            defaultSelection={this.props.defaultSelection}
-            optionNames={this.state.visible}
+            defaultSelection={selected}
+            optionNames={visible}
             onOptionSelect={this.selectOption}
           />
         </div>

--- a/src/components/selector_menu/index.js
+++ b/src/components/selector_menu/index.js
@@ -31,6 +31,7 @@ var SelectorMenu = React.createClass({
 
   getDefaultProps: function() {
     return {
+      defaultSelection: 'All',
       optionsList: []
     };
   },
@@ -44,7 +45,7 @@ var SelectorMenu = React.createClass({
 
   getOptionNames: function() {
     // Returns a list of option names, plus the default value.
-    var options = [this.props.defaultSelection];
+    var options = [this.props.selection || this.state.selected || this.props.defaultSelection];
 
     _.each(this.props.optionsList, function(option) {
       return option.title ? options.push(option.title) : options.push(option.name);
@@ -134,8 +135,19 @@ var SelectorMenu = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    if (nextProps.optionsList.length !== this.props.optionsList.length) {
-      this.setState({ visible: [] });
+    var nextOptions = _.compact(
+      _.pluck(nextProps.optionsList, 'title').concat(_.pluck(nextProps.optionsList, 'name'))
+    );
+
+    var currentOptions = _.compact(
+      _.pluck(this.props.optionsList, 'title').concat(_.pluck(this.props.optionsList, 'name'))
+    );
+
+    if (_.difference(nextOptions, currentOptions).length > 0) {
+      this.setState({
+        visible: [],
+        selected: ''
+      });
     }
   },
 
@@ -143,8 +155,7 @@ var SelectorMenu = React.createClass({
     var wrapperClass = this.state.expanded ? 'selector__wrapper expanded' : 'selector__wrapper';
     var innerClass = this.state.expanded ? 'inner-wrapper expanded' : 'inner-wrapper';
     var visible = this.state.visible.length > 0 ? this.state.visible : this.getOptionNames();
-    var selected = this.state.selected && this.props.defaultSelection === undefined ?
-      this.state.selected : this.props.defaultSelection || 'All';
+    var selected = this.props.selection || this.state.selected || this.props.defaultSelection;
 
     return (
       <div className={wrapperClass}>

--- a/test/selector_menu_test.js
+++ b/test/selector_menu_test.js
@@ -121,4 +121,26 @@ describe("SelectorMenu", function() {
       });
     });
   });
+
+  describe('recieving incoming props ', function() {
+    beforeEach(function() {
+      this.selector.setProps({
+        defaultSelection: 'Sam B.',
+        optionsList: [{ title: 'Sam B.' }, { title: 'Flora W.' }, { title: 'Justin A.' }, { title: 'Nick S.' }]
+      });
+    });
+    it('renders the label correctly', function() {
+      var label = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__label');
+      assert.equal('Sam B.', label.getDOMNode().textContent);
+    });
+    it('renders the list correctly', function() {
+      var list = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__options')
+      assert.lengthOf(list.getDOMNode().children, 4);
+    });
+    it('renders the default label', function() {
+      this.selector.setProps({ defaultSelection: '' });
+      var label = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__label');
+      assert.equal('All', label.getDOMNode().textContent);
+    });
+  });
 });

--- a/test/selector_menu_test.js
+++ b/test/selector_menu_test.js
@@ -122,10 +122,10 @@ describe("SelectorMenu", function() {
     });
   });
 
-  describe('recieving incoming props ', function() {
+  describe('controlled component with selection', function() {
     beforeEach(function() {
       this.selector.setProps({
-        defaultSelection: 'Sam B.',
+        selection: 'Sam B.',
         optionsList: [{ title: 'Sam B.' }, { title: 'Flora W.' }, { title: 'Justin A.' }, { title: 'Nick S.' }]
       });
     });
@@ -137,10 +137,28 @@ describe("SelectorMenu", function() {
       var list = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__options')
       assert.lengthOf(list.getDOMNode().children, 4);
     });
-    it('renders the default label', function() {
-      this.selector.setProps({ defaultSelection: '' });
+    it('adds an unexpected value to the rendered options list', function() {
+      this.selector.setProps({ selection: 'Unassigned' })
+      var list = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__options')
+      assert.lengthOf(list.getDOMNode().children, 5);
+    });
+    it('renders the default label when selection is empty', function() {
+      this.selector.setProps({ selection: '', defaultSelection: 'Foo' });
       var label = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__label');
-      assert.equal('All', label.getDOMNode().textContent);
+      assert.equal('Foo', label.getDOMNode().textContent);
+    });
+    it('overrides selection when new options are passed in', function() {
+      this.selector.setProps({ selection: '' });
+      // Mock the internal state as if the input changed
+      this.selector.setState({ selected: 'Flora W.' });
+      var label = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__label');
+      assert.equal('Flora W.', label.getDOMNode().textContent, 'renders when state set');
+      // Update the optionsList, which should clear out previous state
+      this.selector.setProps({ optionsList: [{ title: 'Foo B.' }] });
+      label = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__label');
+      assert.equal('All', label.getDOMNode().textContent, 'renders the default label');
+      var list = TestUtils.findRenderedDOMComponentWithClass(this.selector, 'selector__options')
+      assert.lengthOf(list.getDOMNode().children, 2, 'renders the new options list');
     });
   });
 });


### PR DESCRIPTION
#### What does it do?
Fixes a bug where the SelectorMenu would retain the props first passed to it. This was happening because props were being copied over to state.

To fix it, we have to first check that props aren't copied over to state and that the selected state gets reset when new options are received. This makes it possible to control the component when the data driving it changes. 

### Where should the reviewer start?
src/components/selector_menu/index.js

#### How should it be manually tested?
The example in the test suite shows how props can change from the outside, but the best way to see this in action is to `npm link` it to sprintly/5columns and notice that the members dropdown filters change as you switch between products.

#### Definition of done:
- [x] Is this appropriately tested?
- [x] Does this need an update to the README or documentation?
- [x] Does this need an update to the examples?
- [x] Does this add new dependencies?
- [x] Does this require a semver version bump?
  - [-] MAJOR
  - [x] MINOR
  - [-] PATCH