### PR TITLE
Adding max-width to tags for overflow styling

### DIFF
--- a/src/less/tags.less
+++ b/src/less/tags.less
@@ -5,6 +5,7 @@
 }
 
 .tags__tag:extend(.button__base) {
+    max-width: 89px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
#### What does it do?
Fixes a styling bug where long tags weren't being shortened with `...` on XPM view.

### Where should the reviewer start?
`tags.less`

#### How should it be manually tested?
Pull down the code. Visit XPM and create a long tag. 

#### Definition of done:
- [-] Is this appropriately tested?
- [-] Does this need an update to the README or documentation?
- [-] Does this need an update to the examples?
- [-] Does this add new dependencies?
- [-] Does this require a semver version bump?
  - [-] MAJOR
  - [-] MINOR
  - [-] PATCH